### PR TITLE
Update FF add-on name

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Transform your new tab into an art gallery, featuring masterpieces from the Art 
 ## Installation
 **Firefox Add-ons**
 - Visit Firefox Add-ons
-- Search "artelier:tab"
+- Search "artelier_tab"
 - Add to Firefox
 
 **Manual Install**


### PR DESCRIPTION
Searching for `artelier:tab` will not result in finding the plugin.

`artelier` and `artelier_tab` just work.